### PR TITLE
Redirect to index.php instead of my_view.php

### DIFF
--- a/pages/redirect.php
+++ b/pages/redirect.php
@@ -60,5 +60,5 @@ user_reset_lost_password_in_progress_count_to_zero( $user_id );
 auth_set_cookies( $user_id, false );
 auth_set_tokens( $user_id );
 
-print_header_redirect( '../../../my_view_page.php' );
+print_header_redirect( '../../../index.php' );
 


### PR DESCRIPTION
Even if the default home page is **my_view.php**, you can change that in your settings (i.e.  `$g_default_home_page='bug_report_page.php'` ).

Unfortunately, the plugin always redirects you to a hard-coded URL my_view.php so the custom home page does not work.

To solve this issue, the following PR changes the redirect URL from `my_view.php` to `index.php`.